### PR TITLE
 Inline optimize flow (no modal) + shadcn-style button + output cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,19 @@
 
 # Prompt Optimizer
 
-Optimize and refine your prompts for LLMs directly on ChatGPT and Gemini. This Chrome MV3 extension injects a small "Optimize" button near site prompt inputs and opens a slick modal to rewrite your text for clarity and effectiveness — using your own API keys.
+Optimize and refine your prompts for LLMs directly on ChatGPT and Gemini. This Chrome MV3 extension injects a small "Optimize" button near site prompt inputs and replaces your text inline — using your own API keys.
 
 </div>
 
 ## Overview
+
 Prompt Optimizer streamlines prompt engineering while you work. It supports multiple providers (OpenAI, Gemini, Anthropic Claude, OpenRouter), stores keys locally via `chrome.storage.sync`, and routes network calls through a background service worker for security. A hardened default meta‑prompt is applied if you don’t provide a custom one.
 
 ## Features
+
 - Inline trigger: Adds an "Optimize" button next to ChatGPT/Gemini input areas.
-- Polished modal: Two‑pane UI for input and optimized output with a one‑click Copy.
+- Inline replace: One‑click refines and replaces your prompt in place.
+- Artifact cleanup: Strips common model tokens from output.
 - Multi‑provider support: OpenAI, Gemini, Anthropic Claude, OpenRouter.
 - Secure key handling: Keys live only in `chrome.storage.sync` (never exposed to page scripts).
 - Options page: Choose provider, set API keys, and an optional master prompt.
@@ -19,6 +22,7 @@ Prompt Optimizer streamlines prompt engineering while you work. It supports mult
 - Clear errors: Friendly messages for missing keys and OpenRouter privacy policy issues.
 
 ## Installation (Unpacked)
+
 1. Download or clone this repository.
 2. Open Chrome and go to `chrome://extensions/`.
 3. Toggle “Developer mode” (top right).
@@ -26,41 +30,46 @@ Prompt Optimizer streamlines prompt engineering while you work. It supports mult
 5. Click the toolbar icon to open the Options page and configure provider + API key(s).
 
 ## Configuration
+
 - Providers supported:
-	- OpenAI (`gpt-4o-mini` by default in code)
-	- Gemini (`gemini-2.5-flash` configured)
-	- Anthropic Claude (`claude-3-sonnet-20240229` configured)
-	- OpenRouter (defaults can be changed; current route set to `deepseek/deepseek-chat-v3.1:free`)
+  - OpenAI (`gpt-4o-mini` by default in code)
+  - Gemini (`gemini-2.5-flash` configured)
+  - Anthropic Claude (`claude-3-sonnet-20240229` configured)
+  - OpenRouter (defaults can be changed; current route set to `deepseek/deepseek-chat-v3.1:free`)
 - Keys are stored via `chrome.storage.sync` and used only by the background service worker.
 - Optional master prompt can be set in Options; a secure default is used otherwise.
 
 ## Usage
+
 1. Visit ChatGPT (`https://chat.openai.com/` or `https://chatgpt.com/`) or Gemini (`https://gemini.google.com/`).
-2. Click the injected "Optimize" button near the site’s input bar.
-3. In the modal, pick a provider (or use your default), paste your initial prompt, and click “Optimize Prompt”.
-4. Copy the improved prompt using the Copy button and paste it back into the site.
-5. If you haven’t set an API key, use the "Open Options" button in the modal header to configure it.
+2. Type your prompt, then click the injected "Optimize" button.
+3. The input is replaced with the improved version inline (no modal).
+4. If no API key is set, the Options page will open to configure it.
 
 ### Tips
+
 - OpenRouter privacy: Free routes may require enabling “Free model publication” (OpenRouter → Settings → Privacy). Otherwise, choose a non‑free model.
 - Inline button missing? SPA UIs can shift; wait a moment or refresh the page.
 
 ## Troubleshooting
-- Missing API key: The modal shows a warning with an “Open Options” shortcut.
+
+- Missing API key: A warning appears and the Options page may open.
 - OpenRouter 404 privacy error: Enable free model publication or switch to a non‑free model.
 - Network/CORS issues: Ensure the extension is reloaded and host permissions include provider APIs (configured in `manifest.json`).
 
 ## Development
+
 - MV3 surfaces:
-	- content script: injects UI, observes DOM, and sends messages
-	- background service worker: owns network requests and provider logic
-	- options page: stores provider choice, keys, and optional master prompt
+  - content script: injects UI, observes DOM, and sends messages
+  - background service worker: owns network requests and provider logic
+  - options page: stores provider choice, keys, and optional master prompt
 - Key files:
-	- `manifest.json` — MV3 wiring
-	- `scripts/content.js` — injection + modal UI
-	- `scripts/background.js` — provider calls + meta‑prompt handling
-	- `options/options.html` / `options/options.js` — settings UI
-	- `styles/content.css` — shared styles (modal + options)
+  - `manifest.json` — MV3 wiring
+- `scripts/content.js` — injection + inline optimization (legacy modal remains unused)
+  - `scripts/background.js` — provider calls + meta‑prompt handling
+  - `options/options.html` / `options/options.js` — settings UI
+  - `styles/content.css` — shared styles (modal + options)
 
 ## Contributing
+
 Contributions are welcome! Please open an issue or a pull request. Consider discussing significant changes in an issue first to align on scope and direction.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Prompt Optimizer streamlines prompt engineering while you work. It supports mult
 	- OpenAI (`gpt-4o-mini` by default in code)
 	- Gemini (`gemini-2.5-flash` configured)
 	- Anthropic Claude (`claude-3-sonnet-20240229` configured)
-	- OpenRouter (defaults can be changed; current route set to `openai/gpt-oss-120b:free`)
+	- OpenRouter (defaults can be changed; current route set to `deepseek/deepseek-chat-v3.1:free`)
 - Keys are stored via `chrome.storage.sync` and used only by the background service worker.
 - Optional master prompt can be set in Options; a secure default is used otherwise.
 

--- a/options/options.html
+++ b/options/options.html
@@ -22,7 +22,7 @@
         <option value="openai">OpenAI (gpt-4o-mini)</option>
         <option value="gemini">Gemini (2.5-flash)</option>
         <option value="claude">Anthropic Claude (sonnet-3)</option>
-        <option value="openrouter">Openrouter (gpt-oss-120b:free)</option>
+        <option value="openrouter">Openrouter (deepseek-chat-v3.1:free)</option>
       </select>
     </div>
 

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -94,7 +94,7 @@ async function callOpenrouter(apiKey, prompt) {
   // Openrouter API (2025)
   const url = 'https://openrouter.ai/api/v1/chat/completions';
   const body = {
-    model: 'openai/gpt-oss-120b:free',
+    model: 'deepseek/deepseek-chat-v3.1:free',
     messages: [
       { role: 'user', content: prompt }
     ],

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -6,32 +6,34 @@
 
 (function () {
   const ID = {
-    button: 'po-optimize-button',
-    modal: 'po-modal',
-    overlay: 'po-overlay',
-    form: 'po-form',
-    input: 'po-input',
-    output: 'po-output',
-    close: 'po-close',
-    provider: 'po-provider',
+    button: "po-optimize-button",
+    modal: "po-modal",
+    overlay: "po-overlay",
+    form: "po-form",
+    input: "po-input",
+    output: "po-output",
+    close: "po-close",
+    provider: "po-provider",
   };
 
   const PROVIDERS = {
-    OPENAI: 'openai',
-    GEMINI: 'gemini',
+    OPENAI: "openai",
+    GEMINI: "gemini",
   };
 
   function escapeHTML(str) {
     return String(str)
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;')
-      .replace(/"/g, '&quot;')
-      .replace(/'/g, '&#039;');
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#039;");
   }
 
   function needsApiKeyHint(text) {
-    return /api key|key not set|add it in options|not set|missing key/i.test(text || '');
+    return /api key|key not set|add it in options|not set|missing key/i.test(
+      text || ""
+    );
   }
 
   function openOptionsPage() {
@@ -40,26 +42,35 @@
         chrome.runtime.openOptionsPage();
         return;
       }
-    } catch (_) { /* ignore */ }
+    } catch (_) {
+      /* ignore */
+    }
     try {
-      chrome.runtime.sendMessage({ type: 'OPEN_OPTIONS' });
-    } catch (_) { /* ignore */ }
+      chrome.runtime.sendMessage({ type: "OPEN_OPTIONS" });
+    } catch (_) {
+      /* ignore */
+    }
   }
 
   function isChatGPT() {
-    return location.hostname === 'chat.openai.com' || location.hostname === 'chatgpt.com';
+    return (
+      location.hostname === "chat.openai.com" ||
+      location.hostname === "chatgpt.com"
+    );
   }
 
   function isGemini() {
-    return location.hostname === 'gemini.google.com';
+    return location.hostname === "gemini.google.com";
   }
 
   function findPromptInput() {
     // ChatGPT textarea selector
     if (isChatGPT()) {
       const selectorCandidates = [
+        'div[contenteditable="true"]',
         'textarea[placeholder*="Send a message" i]',
-        'form textarea',
+        "form textarea",
+        'form div[contenteditable="true"]',
       ];
       for (const sel of selectorCandidates) {
         const el = document.querySelector(sel);
@@ -69,17 +80,107 @@
 
     // Gemini textarea selector
     if (isGemini()) {
-      const geminiSelectors = [
-        'textarea',
-        'div[contenteditable="true"]',
-      ];
+      const geminiSelectors = ["textarea", 'div[contenteditable="true"]'];
       for (const sel of geminiSelectors) {
         const el = document.querySelector(sel);
         if (el) return el;
       }
     }
-
+    // Last resort fallback
+    const fallback = document.querySelector(
+      'textarea, div[contenteditable="true"]'
+    );
+    if (fallback) return fallback;
     return null;
+  }
+
+  function getPromptText(el) {
+    if (!el) return "";
+    if (el.isContentEditable) return el.textContent || "";
+    if (typeof el.value === "string") return el.value || "";
+    return el.textContent || "";
+  }
+
+  function setPromptText(el, text) {
+    if (!el) return;
+    if (el.isContentEditable) {
+      el.focus();
+      el.textContent = text;
+      el.dispatchEvent(new InputEvent("input", { bubbles: true }));
+      return;
+    }
+    try {
+      const proto =
+        window.HTMLTextAreaElement && window.HTMLTextAreaElement.prototype;
+      const setter =
+        proto &&
+        Object.getOwnPropertyDescriptor(proto, "value") &&
+        Object.getOwnPropertyDescriptor(proto, "value").set;
+      if (setter) setter.call(el, text);
+      else el.value = text;
+    } catch (_) {
+      el.value = text;
+    }
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+    el.dispatchEvent(new Event("change", { bubbles: true }));
+  }
+
+  function sanitizeOptimized(text) {
+    if (!text) return text;
+    let cleaned = String(text);
+    const patterns = [
+      /<\|begin_of_sentence\|>/gi,
+      /<\|end_of_sentence\|>/gi,
+      /<\|begin_of_text\|>/gi,
+      /<\|end_of_text\|>/gi,
+      /<\|eot(?:_id)?\|>/gi,
+      /<\|im_end\|>/gi,
+      /<\/?s>/gi,
+      /<｜begin▁of▁sentence｜>/gi,
+      /<｜end▁of▁sentence｜>/gi,
+      /<｜begin▁of▁text｜>/gi,
+      /<｜end▁of▁text｜>/gi,
+      /<｜eot(?:_id)?｜>/gi,
+    ];
+    for (const re of patterns) cleaned = cleaned.replace(re, "");
+    return cleaned.trim();
+  }
+
+  async function inlineOptimize() {
+    const btn = document.getElementById(ID.button);
+    const inputEl = findPromptInput();
+    if (!inputEl) return;
+    const userPrompt = getPromptText(inputEl).trim();
+    if (!userPrompt) {
+      inputEl.focus();
+      return;
+    }
+    try {
+      if (btn) {
+        btn.disabled = true;
+        btn.textContent = "Optimizing…";
+      }
+      const response = await chrome.runtime.sendMessage({
+        type: "OPTIMIZE_PROMPT",
+        payload: { userPrompt },
+      });
+      if (response && response.success && response.optimized) {
+        setPromptText(inputEl, sanitizeOptimized(response.optimized));
+      } else {
+        const msg = response && (response.error || "Optimization failed.");
+        if (needsApiKeyHint(msg)) openOptionsPage();
+        else alert(msg);
+      }
+    } catch (err) {
+      const emsg = err && (err.message || String(err));
+      if (needsApiKeyHint(emsg)) openOptionsPage();
+      else alert(emsg);
+    } finally {
+      if (btn) {
+        btn.disabled = false;
+        btn.textContent = "Optimize";
+      }
+    }
   }
 
   function injectButton(target) {
@@ -90,22 +191,25 @@
     if (existing && existing.isConnected) return;
 
     // Create button
-    const btn = document.createElement('button');
+    const btn = document.createElement("button");
     btn.id = ID.button;
-    btn.type = 'button';
-    btn.textContent = 'Optimize';
-    btn.className = 'po-inline-trigger';
-    btn.addEventListener('click', openModal);
+    btn.type = "button";
+    btn.textContent = "Optimize";
+    btn.className = "po-inline-trigger";
+    btn.addEventListener("click", inlineOptimize);
 
     // ChatGPT placement strategy
     if (isChatGPT()) {
       try {
         // Composer form
-        const form = target.closest('form');
+        const form = target.closest("form");
         // Try inner flex container that holds the + icon and textarea
-        const plusIcon = form ? form.querySelector('button, div svg') : null;
+        const plusIcon = form ? form.querySelector("button, div svg") : null;
         // Right action cluster (microphone / mode) - attempt to insert before it
-        const rightCluster = form ? form.querySelector('[data-testid*="send"]') || form.querySelector('button[aria-label*="Send" i]') : null;
+        const rightCluster = form
+          ? form.querySelector('[data-testid*="send"]') ||
+            form.querySelector('button[aria-label*="Send" i]')
+          : null;
 
         if (rightCluster && rightCluster.parentElement) {
           rightCluster.parentElement.insertBefore(btn, rightCluster);
@@ -115,14 +219,18 @@
           plusIcon.parentElement.insertBefore(btn, plusIcon.nextSibling);
           return;
         }
-      } catch (e) { /* swallow and fallback */ }
+      } catch (e) {
+        /* swallow and fallback */
+      }
     }
 
     // Gemini placement strategy
     if (isGemini()) {
       try {
         // Prefer the provided leading actions wrapper (stable anchor)
-        const leadingWrapper = document.querySelector('.leading-actions-wrapper');
+        const leadingWrapper = document.querySelector(
+          ".leading-actions-wrapper"
+        );
         if (leadingWrapper) {
           // Avoid duplicate
           if (!document.getElementById(ID.button)) {
@@ -131,73 +239,83 @@
           return;
         }
         // Fallback: Card container that holds the textarea (contenteditable) and actions
-        const card = target.closest('div');
-        if (card && card.querySelector('textarea, div[contenteditable="true"]')) {
+        const card = target.closest("div");
+        if (
+          card &&
+          card.querySelector('textarea, div[contenteditable="true"]')
+        ) {
           card.appendChild(btn);
           return;
         }
-      } catch (e) { /* swallow */ }
+      } catch (e) {
+        /* swallow */
+      }
     }
 
     // Fallback: append after target input
-    target.parentElement ? target.parentElement.appendChild(btn) : document.body.appendChild(btn);
+    target.parentElement
+      ? target.parentElement.appendChild(btn)
+      : document.body.appendChild(btn);
   }
 
   function openModal() {
     if (document.getElementById(ID.modal)) return; // one modal at a time
 
-    const overlay = document.createElement('div');
+    const overlay = document.createElement("div");
     overlay.id = ID.overlay;
 
-    const modal = document.createElement('div');
+    const modal = document.createElement("div");
     modal.id = ID.modal;
-    modal.setAttribute('role', 'dialog');
-    modal.setAttribute('aria-modal', 'true');
-    modal.setAttribute('tabindex', '-1');
+    modal.setAttribute("role", "dialog");
+    modal.setAttribute("aria-modal", "true");
+    modal.setAttribute("tabindex", "-1");
 
     // Header
-    const header = document.createElement('div');
-    header.className = 'po-header';
-    const title = document.createElement('h2');
-    title.className = 'po-title';
+    const header = document.createElement("div");
+    header.className = "po-header";
+    const title = document.createElement("h2");
+    title.className = "po-title";
     title.innerHTML = 'Prompt Optimizer <span class="po-badge">BETA</span>';
 
-  const headerRight = document.createElement('div');
-  headerRight.className = 'po-header-right';
+    const headerRight = document.createElement("div");
+    headerRight.className = "po-header-right";
 
-  const openOptsBtn = document.createElement('button');
-  openOptsBtn.type = 'button';
-  openOptsBtn.className = 'po-head-btn';
-  openOptsBtn.textContent = 'Open Options';
-  openOptsBtn.addEventListener('click', (e) => { e.stopPropagation(); openOptionsPage(); });
+    const openOptsBtn = document.createElement("button");
+    openOptsBtn.type = "button";
+    openOptsBtn.className = "po-head-btn";
+    openOptsBtn.textContent = "Open Options";
+    openOptsBtn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      openOptionsPage();
+    });
 
-  const closeBtn = document.createElement('button');
-  closeBtn.className = 'po-close-btn';
-  closeBtn.type = 'button';
-  closeBtn.textContent = '×';
-  closeBtn.setAttribute('aria-label', 'Close dialog');
+    const closeBtn = document.createElement("button");
+    closeBtn.className = "po-close-btn";
+    closeBtn.type = "button";
+    closeBtn.textContent = "×";
+    closeBtn.setAttribute("aria-label", "Close dialog");
 
-  headerRight.appendChild(openOptsBtn);
-  headerRight.appendChild(closeBtn);
+    headerRight.appendChild(openOptsBtn);
+    headerRight.appendChild(closeBtn);
 
-  header.appendChild(title);
-  header.appendChild(headerRight);
+    header.appendChild(title);
+    header.appendChild(headerRight);
 
-    const form = document.createElement('form');
+    const form = document.createElement("form");
     form.id = ID.form;
 
     // Provider + Input column
-    const grid = document.createElement('div');
-    grid.className = 'po-grid';
+    const grid = document.createElement("div");
+    grid.className = "po-grid";
 
-    const colLeft = document.createElement('div');
-    colLeft.className = 'po-col';
+    const colLeft = document.createElement("div");
+    colLeft.className = "po-col";
 
-    const providerRow = document.createElement('div');
-    const providerLabel = document.createElement('label');
-    providerLabel.textContent = 'Provider';
-    providerLabel.setAttribute('for', ID.provider);
-    const providerSelect = document.createElement('select');
+    const providerRow = document.createElement("div");
+    const providerLabel = document.createElement("label");
+    providerLabel.textContent = "Provider";
+    providerLabel.setAttribute("for", ID.provider);
+    const providerSelect = document.createElement("select");
     providerSelect.id = ID.provider;
     providerSelect.innerHTML = `
       <option value="openai">OpenAI (gpt-4o-mini)</option>
@@ -208,49 +326,49 @@
     providerRow.appendChild(providerLabel);
     providerRow.appendChild(providerSelect);
 
-    const input = document.createElement('textarea');
+    const input = document.createElement("textarea");
     input.id = ID.input;
-    input.placeholder = 'Enter your initial prompt...';
+    input.placeholder = "Enter your initial prompt...";
     input.rows = 10;
-    input.setAttribute('aria-label', 'Initial prompt');
+    input.setAttribute("aria-label", "Initial prompt");
 
-    const submit = document.createElement('button');
-    submit.type = 'submit';
-    submit.textContent = 'Optimize Prompt';
-    submit.className = 'po-primary';
+    const submit = document.createElement("button");
+    submit.type = "submit";
+    submit.textContent = "Optimize Prompt";
+    submit.className = "po-primary";
 
     colLeft.appendChild(providerRow);
     colLeft.appendChild(input);
     colLeft.appendChild(submit);
 
     // Output column
-    const colRight = document.createElement('div');
-    colRight.className = 'po-col';
-    const outputWrap = document.createElement('div');
-    outputWrap.className = 'po-output-wrap';
+    const colRight = document.createElement("div");
+    colRight.className = "po-col";
+    const outputWrap = document.createElement("div");
+    outputWrap.className = "po-output-wrap";
 
-    const output = document.createElement('textarea');
+    const output = document.createElement("textarea");
     output.id = ID.output;
-    output.placeholder = 'Optimized prompt will appear here...';
+    output.placeholder = "Optimized prompt will appear here...";
     output.rows = 14;
     output.readOnly = true;
-    output.className = 'po-output';
-    output.setAttribute('aria-label', 'Optimized prompt output');
+    output.className = "po-output";
+    output.setAttribute("aria-label", "Optimized prompt output");
 
-    const toolbar = document.createElement('div');
-    toolbar.className = 'po-toolbar';
+    const toolbar = document.createElement("div");
+    toolbar.className = "po-toolbar";
 
-    const copyBtn = document.createElement('button');
-    copyBtn.type = 'button';
-    copyBtn.className = 'po-tool-btn';
-    copyBtn.textContent = 'Copy';
+    const copyBtn = document.createElement("button");
+    copyBtn.type = "button";
+    copyBtn.className = "po-tool-btn";
+    copyBtn.textContent = "Copy";
     copyBtn.disabled = true;
-    copyBtn.addEventListener('click', () => {
+    copyBtn.addEventListener("click", () => {
       const optimized = output.value.trim();
       if (!optimized) return;
       navigator.clipboard.writeText(optimized);
-      copyBtn.textContent = 'Copied!';
-      setTimeout(() => (copyBtn.textContent = 'Copy'), 1200);
+      copyBtn.textContent = "Copied!";
+      setTimeout(() => (copyBtn.textContent = "Copy"), 1200);
     });
 
     toolbar.appendChild(copyBtn);
@@ -261,9 +379,9 @@
     grid.appendChild(colLeft);
     grid.appendChild(colRight);
 
-    const errorMsg = document.createElement('div');
-    errorMsg.id = 'po-error';
-    errorMsg.setAttribute('role', 'alert');
+    const errorMsg = document.createElement("div");
+    errorMsg.id = "po-error";
+    errorMsg.setAttribute("role", "alert");
 
     form.appendChild(grid);
     form.appendChild(errorMsg);
@@ -274,58 +392,67 @@
     overlay.appendChild(modal);
     document.body.appendChild(overlay);
 
-    closeBtn.addEventListener('click', () => overlay.remove());
-    overlay.addEventListener('click', (e) => { if (e.target === overlay) overlay.remove(); });
+    closeBtn.addEventListener("click", () => overlay.remove());
+    overlay.addEventListener("click", (e) => {
+      if (e.target === overlay) overlay.remove();
+    });
     setTimeout(() => modal.focus(), 60);
 
-    chrome.storage.sync.get(['po_provider'], (res) => { if (res.po_provider) providerSelect.value = res.po_provider; });
+    chrome.storage.sync.get(["po_provider"], (res) => {
+      if (res.po_provider) providerSelect.value = res.po_provider;
+    });
 
-    form.addEventListener('submit', async (e) => {
+    form.addEventListener("submit", async (e) => {
       e.preventDefault();
       submit.disabled = true;
-      submit.textContent = 'Optimizing…';
-      output.value = '';
-      errorMsg.textContent = '';
+      submit.textContent = "Optimizing…";
+      output.value = "";
+      errorMsg.textContent = "";
       copyBtn.disabled = true;
       try {
         const provider = providerSelect.value;
         const userPrompt = input.value.trim();
         if (!userPrompt) {
-          errorMsg.textContent = 'Please enter a prompt.';
+          errorMsg.textContent = "Please enter a prompt.";
           submit.disabled = false;
-          submit.textContent = 'Optimize Prompt';
+          submit.textContent = "Optimize Prompt";
           return;
         }
         const response = await chrome.runtime.sendMessage({
-          type: 'OPTIMIZE_PROMPT', payload: { provider, userPrompt }
+          type: "OPTIMIZE_PROMPT",
+          payload: { provider, userPrompt },
         });
         if (response && response.success) {
-          output.value = response.optimized || '(No content)';
+          output.value = response.optimized || "(No content)";
           copyBtn.disabled = !response.optimized;
         } else {
-          const msg = response?.error || 'Optimization failed.';
+          const msg = response?.error || "Optimization failed.";
           if (needsApiKeyHint(msg)) {
-            errorMsg.innerHTML = `${escapeHTML(msg)}<br><span class="po-hint">Add your API key to continue. Click the extension icon to open the Options page, or <button type="button" class="po-mini-btn" id="po-open-options-btn">Open Options</button>.</span>`;
-            const btn = document.getElementById('po-open-options-btn');
-            if (btn) btn.addEventListener('click', openOptionsPage);
+            errorMsg.innerHTML = `${escapeHTML(
+              msg
+            )}<br><span class="po-hint">Add your API key to continue. Click the extension icon to open the Options page, or <button type="button" class="po-mini-btn" id="po-open-options-btn">Open Options</button>.</span>`;
+            const btn = document.getElementById("po-open-options-btn");
+            if (btn) btn.addEventListener("click", openOptionsPage);
           } else {
             errorMsg.textContent = msg;
           }
           copyBtn.disabled = true;
         }
       } catch (err) {
-        const emsg = 'Error: ' + (err?.message || String(err));
+        const emsg = "Error: " + (err?.message || String(err));
         if (needsApiKeyHint(emsg)) {
-          errorMsg.innerHTML = `${escapeHTML(emsg)}<br><span class="po-hint">Add your API key to continue. Click the extension icon to open the Options page, or <button type="button" class="po-mini-btn" id="po-open-options-btn">Open Options</button>.</span>`;
-          const btn = document.getElementById('po-open-options-btn');
-          if (btn) btn.addEventListener('click', openOptionsPage);
+          errorMsg.innerHTML = `${escapeHTML(
+            emsg
+          )}<br><span class="po-hint">Add your API key to continue. Click the extension icon to open the Options page, or <button type="button" class="po-mini-btn" id="po-open-options-btn">Open Options</button>.</span>`;
+          const btn = document.getElementById("po-open-options-btn");
+          if (btn) btn.addEventListener("click", openOptionsPage);
         } else {
           errorMsg.textContent = emsg;
         }
         copyBtn.disabled = true;
       } finally {
         submit.disabled = false;
-        submit.textContent = 'Optimize Prompt';
+        submit.textContent = "Optimize Prompt";
       }
     });
   }
@@ -337,7 +464,10 @@
 
   // Observe dynamic page updates (both ChatGPT and Gemini are SPA-like)
   const observer = new MutationObserver(() => ensureUI());
-  observer.observe(document.documentElement, { subtree: true, childList: true });
+  observer.observe(document.documentElement, {
+    subtree: true,
+    childList: true,
+  });
 
   // Initial attempt
   ensureUI();

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -203,7 +203,7 @@
       <option value="openai">OpenAI (gpt-4o-mini)</option>
       <option value="gemini">Gemini (2.5-flash)</option>
       <option value="claude">Anthropic Claude (sonnet-3)</option>
-      <option value="openrouter">Openrouter (gpt-oss-120b:free)</option>
+      <option value="openrouter">Openrouter (deepseek-chat-v3.1:free)</option>
     `;
     providerRow.appendChild(providerLabel);
     providerRow.appendChild(providerSelect);

--- a/styles/content.css
+++ b/styles/content.css
@@ -8,9 +8,24 @@
   font-size: 13px;
   min-height: 18px;
 }
-.po-hint { color:#9db1c3; font-size:12px; }
-.po-mini-btn { margin-left:6px; padding:4px 8px; font-size:12px; border-radius:8px; border:1px solid #2a3746; background:#1d2732; color:#d6dde5; cursor:pointer; }
-.po-mini-btn:hover { background:#253242; border-color:#385068; }
+.po-hint {
+  color: #9db1c3;
+  font-size: 12px;
+}
+.po-mini-btn {
+  margin-left: 6px;
+  padding: 4px 8px;
+  font-size: 12px;
+  border-radius: 8px;
+  border: 1px solid #2a3746;
+  background: #1d2732;
+  color: #d6dde5;
+  cursor: pointer;
+}
+.po-mini-btn:hover {
+  background: #253242;
+  border-color: #385068;
+}
 /* Styles for injected UI and options */
 
 /* Button near input */
@@ -18,126 +33,486 @@
   margin-left: 8px;
   padding: 6px 10px;
   border-radius: 6px;
-  border: 1px solid rgba(0,0,0,0.12);
+  border: 1px solid rgba(0, 0, 0, 0.12);
   background: #1a73e8;
   color: #fff;
   cursor: pointer;
   font-size: 14px;
 }
-#po-optimize-button.po-btn:hover { background: #1669c1; }
+#po-optimize-button.po-btn:hover {
+  background: #1669c1;
+}
 
 /* Modal */
 #po-overlay {
-  position: fixed; inset: 0; background: rgba(0,0,0,0.4); z-index: 2147483646;
-  display: flex; align-items: center; justify-content: center;
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 2147483646;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 #po-modal {
-  background: #101317; color: #e5e9f0; width: min(840px, 94vw); max-height: 84vh; overflow: hidden;
-  border-radius: 16px; box-shadow: 0 16px 48px -8px rgba(0,0,0,0.55), 0 0 0 1px rgba(255,255,255,0.03);
-  display: flex; flex-direction: column;
+  background: #101317;
+  color: #e5e9f0;
+  width: min(840px, 94vw);
+  max-height: 84vh;
+  overflow: hidden;
+  border-radius: 16px;
+  box-shadow: 0 16px 48px -8px rgba(0, 0, 0, 0.55),
+    0 0 0 1px rgba(255, 255, 255, 0.03);
+  display: flex;
+  flex-direction: column;
   isolation: isolate; /* create new stacking context */
 }
-#po-modal, #po-modal * , #po-modal *::before, #po-modal *::after { box-sizing: border-box; }
-#po-modal button, #po-modal select, #po-modal textarea, #po-modal input {
-  font: inherit; color: inherit; background-clip: padding-box;
+#po-modal,
+#po-modal *,
+#po-modal *::before,
+#po-modal *::after {
+  box-sizing: border-box;
 }
-#po-modal button, #po-modal select { -webkit-appearance: none; appearance: none; }
-#po-modal h2 { margin: 0 0 8px 0; font-size: 18px; }
-#po-close { float: right; background: transparent; border: none; font-size: 20px; cursor: pointer; }
+#po-modal button,
+#po-modal select,
+#po-modal textarea,
+#po-modal input {
+  font: inherit;
+  color: inherit;
+  background-clip: padding-box;
+}
+#po-modal button,
+#po-modal select {
+  -webkit-appearance: none;
+  appearance: none;
+}
+#po-modal h2 {
+  margin: 0 0 8px 0;
+  font-size: 18px;
+}
+#po-close {
+  float: right;
+  background: transparent;
+  border: none;
+  font-size: 20px;
+  cursor: pointer;
+}
 
 /* Layout */
-#po-form { display: flex; flex-direction: column; gap: 14px; padding: 20px 24px 24px; overflow-y: auto; }
-#po-form textarea { width: 100%; padding: 14px 16px; border: 1px solid #253040; background:#161b21; color:#e5e9f0; border-radius: 12px; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size:14px; line-height:1.45; resize: vertical; }
-#po-form textarea:focus { outline: 2px solid #1a73e8; outline-offset: 2px; }
-#po-form select { width: 220px; padding: 8px 10px; border-radius: 10px; background:#161b21; border:1px solid #253040; color:#e5e9f0; }
-#po-form select:focus { outline:2px solid #1a73e8; }
+#po-form {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 20px 24px 24px;
+  overflow-y: auto;
+}
+#po-form textarea {
+  width: 100%;
+  padding: 14px 16px;
+  border: 1px solid #253040;
+  background: #161b21;
+  color: #e5e9f0;
+  border-radius: 12px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 14px;
+  line-height: 1.45;
+  resize: vertical;
+}
+#po-form textarea:focus {
+  outline: 2px solid #1a73e8;
+  outline-offset: 2px;
+}
+#po-form select {
+  width: 220px;
+  padding: 8px 10px;
+  border-radius: 10px;
+  background: #161b21;
+  border: 1px solid #253040;
+  color: #e5e9f0;
+}
+#po-form select:focus {
+  outline: 2px solid #1a73e8;
+}
 
 /* Buttons */
-.po-primary { background: linear-gradient(90deg,#1a73e8,#4386f5); color:#fff; border:none; border-radius: 10px; padding:10px 18px; font-size:14px; font-weight:500; letter-spacing:.3px; cursor:pointer; box-shadow:0 2px 6px rgba(26,115,232,.35); transition: background .18s, transform .15s; }
-.po-primary:hover:not(:disabled) { background: linear-gradient(90deg,#3b82f6,#1a73e8); }
-.po-primary:active:not(:disabled) { transform: translateY(1px); }
-.po-primary:disabled { opacity:.55; cursor: default; box-shadow:none; }
+.po-primary {
+  background: linear-gradient(90deg, #1a73e8, #4386f5);
+  color: #fff;
+  border: none;
+  border-radius: 10px;
+  padding: 10px 18px;
+  font-size: 14px;
+  font-weight: 500;
+  letter-spacing: 0.3px;
+  cursor: pointer;
+  box-shadow: 0 2px 6px rgba(26, 115, 232, 0.35);
+  transition: background 0.18s, transform 0.15s;
+}
+.po-primary:hover:not(:disabled) {
+  background: linear-gradient(90deg, #3b82f6, #1a73e8);
+}
+.po-primary:active:not(:disabled) {
+  transform: translateY(1px);
+}
+.po-primary:disabled {
+  opacity: 0.55;
+  cursor: default;
+  box-shadow: none;
+}
 
 /* Header */
-.po-header { display:flex; align-items:center; justify-content: space-between; padding:16px 20px 8px; border-bottom:1px solid #1f2630; background: linear-gradient(180deg,#12171d,#0f1419); }
-.po-title { font-size:17px; font-weight:600; letter-spacing:.4px; margin:0; display:flex; align-items:center; gap:8px; }
-.po-badge { background:#1a73e8; color:#fff; font-size:10px; padding:2px 6px; border-radius:6px; letter-spacing:.5px; }
-.po-close-btn { background:transparent; color:#8592a1; border:none; font-size:20px; cursor:pointer; padding:4px 6px; border-radius:8px; }
-.po-close-btn:hover { background:#1d252d; color:#d9dee3; }
-.po-header-right { display:flex; align-items:center; gap:10px; }
-.po-head-btn { background:#1d2732; border:1px solid #2a3746; color:#d6dde5; padding:6px 10px; font-size:12px; border-radius:8px; cursor:pointer; }
-.po-head-btn:hover { background:#253242; border-color:#385068; }
+.po-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px 8px;
+  border-bottom: 1px solid #1f2630;
+  background: linear-gradient(180deg, #12171d, #0f1419);
+}
+.po-title {
+  font-size: 17px;
+  font-weight: 600;
+  letter-spacing: 0.4px;
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.po-badge {
+  background: #1a73e8;
+  color: #fff;
+  font-size: 10px;
+  padding: 2px 6px;
+  border-radius: 6px;
+  letter-spacing: 0.5px;
+}
+.po-close-btn {
+  background: transparent;
+  color: #8592a1;
+  border: none;
+  font-size: 20px;
+  cursor: pointer;
+  padding: 4px 6px;
+  border-radius: 8px;
+}
+.po-close-btn:hover {
+  background: #1d252d;
+  color: #d9dee3;
+}
+.po-header-right {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.po-head-btn {
+  background: #1d2732;
+  border: 1px solid #2a3746;
+  color: #d6dde5;
+  padding: 6px 10px;
+  font-size: 12px;
+  border-radius: 8px;
+  cursor: pointer;
+}
+.po-head-btn:hover {
+  background: #253242;
+  border-color: #385068;
+}
 
 /* Two column responsive layout */
-.po-grid { display:flex; gap:18px; flex-wrap:wrap; }
-.po-col { flex:1 1 360px; display:flex; flex-direction:column; gap:14px; }
+.po-grid {
+  display: flex;
+  gap: 18px;
+  flex-wrap: wrap;
+}
+.po-col {
+  flex: 1 1 360px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
 
 /* Output section */
-.po-output-wrap { position:relative; }
-.po-output { min-height:180px; max-height:380px; overflow:auto; }
-.po-toolbar { position:absolute; top:10px; right:12px; display:flex; gap:8px; }
-.po-tool-btn { background:#1d2732; border:1px solid #2a3746; color:#d6dde5; padding:6px 12px; font-size:12px; border-radius:8px; cursor:pointer; display:flex; align-items:center; gap:6px; transition: background .2s, border-color .2s; }
-.po-tool-btn:hover { background:#253242; border-color:#385068; }
-.po-tool-btn:active { background:#1a252f; }
+.po-output-wrap {
+  position: relative;
+}
+.po-output {
+  min-height: 180px;
+  max-height: 380px;
+  overflow: auto;
+}
+.po-toolbar {
+  position: absolute;
+  top: 10px;
+  right: 12px;
+  display: flex;
+  gap: 8px;
+}
+.po-tool-btn {
+  background: #1d2732;
+  border: 1px solid #2a3746;
+  color: #d6dde5;
+  padding: 6px 12px;
+  font-size: 12px;
+  border-radius: 8px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  transition: background 0.2s, border-color 0.2s;
+}
+.po-tool-btn:hover {
+  background: #253242;
+  border-color: #385068;
+}
+.po-tool-btn:active {
+  background: #1a252f;
+}
 
 /* Error area */
-#po-error { background:transparent; padding:0; }
+#po-error {
+  background: transparent;
+  padding: 0;
+}
 
 /* Integrated Optimize trigger near site inputs */
-.po-inline-trigger { margin-left:8px; background:linear-gradient(90deg,#1a73e8,#4386f5); color:#fff; border:none; padding:6px 14px; border-radius:8px; font-size:13px; font-weight:500; cursor:pointer; display:inline-flex; align-items:center; gap:6px; box-shadow:0 1px 4px rgba(0,0,0,.4); }
-.po-inline-trigger:hover { background:linear-gradient(90deg,#3b82f6,#1a73e8); }
-.po-inline-trigger:active { transform:translateY(1px); }
+.po-inline-trigger {
+  margin-left: 8px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  height: 32px;
+  padding: 0 12px;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: #2563eb; /* shadcn primary vibe */
+  color: #fff;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s,
+    transform 0.05s, opacity 0.2s;
+}
+.po-inline-trigger:hover:not(:disabled) {
+  background: #1d4ed8;
+}
+.po-inline-trigger:active:not(:disabled) {
+  transform: translateY(1px);
+}
+.po-inline-trigger:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.55);
+}
+.po-inline-trigger:disabled {
+  opacity: 0.7;
+  cursor: default;
+  box-shadow: none;
+}
 
 /* Scrollbar styling (webkit) */
-#po-modal ::-webkit-scrollbar { width:10px; }
-#po-modal ::-webkit-scrollbar-track { background: #12171d; }
-#po-modal ::-webkit-scrollbar-thumb { background:#253242; border-radius:6px; }
-#po-modal ::-webkit-scrollbar-thumb:hover { background:#32506c; }
+#po-modal ::-webkit-scrollbar {
+  width: 10px;
+}
+#po-modal ::-webkit-scrollbar-track {
+  background: #12171d;
+}
+#po-modal ::-webkit-scrollbar-thumb {
+  background: #253242;
+  border-radius: 6px;
+}
+#po-modal ::-webkit-scrollbar-thumb:hover {
+  background: #32506c;
+}
 
 @media (max-width: 680px) {
-  #po-form { padding:16px 16px 20px; }
-  .po-toolbar { top:8px; right:8px; }
-  .po-primary { padding:9px 16px; }
+  #po-form {
+    padding: 16px 16px 20px;
+  }
+  .po-toolbar {
+    top: 8px;
+    right: 8px;
+  }
+  .po-primary {
+    padding: 9px 16px;
+  }
 }
 
 /* ================= Options Page Theme ================= */
-body:has(.po-opt-panel) { background:#0d1116; color:#e5e9f0; font-family: system-ui,-apple-system,Segoe UI,Roboto,sans-serif; padding:12px; }
-.po-opt-wrap { max-width:980px; margin:36px auto; padding:0 12px; }
-.po-opt-wrap .po-opt-h1 { text-align:center; }
-.po-opt-wrap .po-opt-sub { text-align:center; max-width:760px; margin-left:auto; margin-right:auto; }
-.po-opt-wrap .po-opt-disclaimer { max-width:860px; margin-left:auto; margin-right:auto; }
-.po-opt-h1 { margin:8px 0 4px; font-size:28px; font-weight:600; letter-spacing:.5px; background:linear-gradient(90deg,#4ea1ff,#1a73e8); -webkit-background-clip:text; background-clip:text; color:transparent; }
-.po-opt-sub { margin:0 0 22px; font-size:13px; color:#93a2b4; line-height:1.5; }
-.po-opt-disclaimer { margin:10px 0 18px; padding:12px 14px; border-radius:12px; background:rgba(255,193,7,0.08); border:1px solid rgba(255,193,7,0.25); color:#e7d9b1; font-size:12.5px; line-height:1.5; }
-.po-opt-panel { max-width:860px; width:100%; margin:0 auto; background:#10151b; border:1px solid #1e2732; border-radius:18px; padding:26px 28px 34px; box-shadow:0 8px 28px -8px rgba(0,0,0,.55),0 0 0 1px rgba(255,255,255,0.02); }
-.po-opt-section { display:flex; flex-direction:column; gap:10px; margin-bottom:22px; }
-.po-opt-label { font-size:13px; font-weight:600; letter-spacing:.4px; text-transform:uppercase; color:#9db1c3; }
-.po-opt-optional { font-weight:400; font-size:11px; color:#586675; }
-.po-opt-input, .po-opt-textarea, .po-opt-select { width:100%; box-sizing:border-box; background:#161c22; border:1px solid #253242; color:#e5e9f0; border-radius:12px; padding:12px 14px; font-size:14px; font-family: ui-monospace,SFMono-Regular,Menlo,Consolas,monospace; }
-.po-opt-select { font-family: system-ui,-apple-system,Segoe UI,Roboto,sans-serif; }
-.po-opt-textarea { line-height:1.45; resize:vertical; }
-.po-opt-input:focus, .po-opt-textarea:focus, .po-opt-select:focus { outline:2px solid #1a73e8; outline-offset:2px; }
-.po-opt-hint { font-size:11px; color:#6e8092; }
-.po-opt-actions { display:flex; align-items:center; gap:14px; margin-top:6px; }
-.po-opt-save { font-size:14px; }
-.po-opt-status { font-size:12px; color:#6ca8ff; min-width:60px; }
+body:has(.po-opt-panel) {
+  background: #0d1116;
+  color: #e5e9f0;
+  font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  padding: 12px;
+}
+.po-opt-wrap {
+  max-width: 980px;
+  margin: 36px auto;
+  padding: 0 12px;
+}
+.po-opt-wrap .po-opt-h1 {
+  text-align: center;
+}
+.po-opt-wrap .po-opt-sub {
+  text-align: center;
+  max-width: 760px;
+  margin-left: auto;
+  margin-right: auto;
+}
+.po-opt-wrap .po-opt-disclaimer {
+  max-width: 860px;
+  margin-left: auto;
+  margin-right: auto;
+}
+.po-opt-h1 {
+  margin: 8px 0 4px;
+  font-size: 28px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  background: linear-gradient(90deg, #4ea1ff, #1a73e8);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.po-opt-sub {
+  margin: 0 0 22px;
+  font-size: 13px;
+  color: #93a2b4;
+  line-height: 1.5;
+}
+.po-opt-disclaimer {
+  margin: 10px 0 18px;
+  padding: 12px 14px;
+  border-radius: 12px;
+  background: rgba(255, 193, 7, 0.08);
+  border: 1px solid rgba(255, 193, 7, 0.25);
+  color: #e7d9b1;
+  font-size: 12.5px;
+  line-height: 1.5;
+}
+.po-opt-panel {
+  max-width: 860px;
+  width: 100%;
+  margin: 0 auto;
+  background: #10151b;
+  border: 1px solid #1e2732;
+  border-radius: 18px;
+  padding: 26px 28px 34px;
+  box-shadow: 0 8px 28px -8px rgba(0, 0, 0, 0.55),
+    0 0 0 1px rgba(255, 255, 255, 0.02);
+}
+.po-opt-section {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-bottom: 22px;
+}
+.po-opt-label {
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.4px;
+  text-transform: uppercase;
+  color: #9db1c3;
+}
+.po-opt-optional {
+  font-weight: 400;
+  font-size: 11px;
+  color: #586675;
+}
+.po-opt-input,
+.po-opt-textarea,
+.po-opt-select {
+  width: 100%;
+  box-sizing: border-box;
+  background: #161c22;
+  border: 1px solid #253242;
+  color: #e5e9f0;
+  border-radius: 12px;
+  padding: 12px 14px;
+  font-size: 14px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+.po-opt-select {
+  font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+}
+.po-opt-textarea {
+  line-height: 1.45;
+  resize: vertical;
+}
+.po-opt-input:focus,
+.po-opt-textarea:focus,
+.po-opt-select:focus {
+  outline: 2px solid #1a73e8;
+  outline-offset: 2px;
+}
+.po-opt-hint {
+  font-size: 11px;
+  color: #6e8092;
+}
+.po-opt-actions {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin-top: 6px;
+}
+.po-opt-save {
+  font-size: 14px;
+}
+.po-opt-status {
+  font-size: 12px;
+  color: #6ca8ff;
+  min-width: 60px;
+}
 
-@media (max-width:780px) {
-  .po-opt-wrap { margin:20px auto; }
-  .po-opt-panel { padding:22px 20px 30px; }
-  .po-opt-h1 { font-size:24px; }
+@media (max-width: 780px) {
+  .po-opt-wrap {
+    margin: 20px auto;
+  }
+  .po-opt-panel {
+    padding: 22px 20px 30px;
+  }
+  .po-opt-h1 {
+    font-size: 24px;
+  }
 }
 
 /* Compact layout for narrow extension popups */
 @media (max-width: 440px) {
-  body:has(.po-opt-panel) { padding:10px; }
-  .po-opt-wrap { margin:12px auto; padding:0 8px; }
-  .po-opt-panel { padding:16px 14px 18px; border-radius:14px; }
-  .po-opt-h1 { font-size:20px; margin:4px 0 8px; }
-  .po-opt-sub { font-size:12px; margin-bottom:12px; }
-  .po-opt-label { font-size:11px; }
-  .po-opt-input, .po-opt-textarea, .po-opt-select { padding:10px 12px; font-size:13px; }
-  .po-opt-textarea { min-height:96px; max-height:220px; resize: vertical; }
-  .po-opt-actions { gap:10px; }
-  .po-opt-status { font-size:11px; }
+  body:has(.po-opt-panel) {
+    padding: 10px;
+  }
+  .po-opt-wrap {
+    margin: 12px auto;
+    padding: 0 8px;
+  }
+  .po-opt-panel {
+    padding: 16px 14px 18px;
+    border-radius: 14px;
+  }
+  .po-opt-h1 {
+    font-size: 20px;
+    margin: 4px 0 8px;
+  }
+  .po-opt-sub {
+    font-size: 12px;
+    margin-bottom: 12px;
+  }
+  .po-opt-label {
+    font-size: 11px;
+  }
+  .po-opt-input,
+  .po-opt-textarea,
+  .po-opt-select {
+    padding: 10px 12px;
+    font-size: 13px;
+  }
+  .po-opt-textarea {
+    min-height: 96px;
+    max-height: 220px;
+    resize: vertical;
+  }
+  .po-opt-actions {
+    gap: 10px;
+  }
+  .po-opt-status {
+    font-size: 11px;
+  }
 }


### PR DESCRIPTION
### Summary
- Replace the modal flow with inline optimization: clicking Optimize now directly enhances and replaces the current prompt in ChatGPT/Gemini.
- Restyle the injected button to a shadcn/ui-like primary button.
- Strip common model artifact tokens from the optimized output.
- Update README to reflect the new inline usage and behavior.

### Changes
- scripts/content.js
  - Add `inlineOptimize()` to read current input, call background, replace text, and dispatch input/change events.
  - Improve input detection: include `contenteditable` and fallback selectors.
  - Add `sanitizeOptimized()` to remove tokens like `<｜begin▁of▁sentence｜>`, `<|begin_of_text|>`, etc.
  - Wire Optimize button click to inline flow; auto-open Options if key missing.
- styles/content.css
  - Update `.po-inline-trigger` to shadcn-like primary style (rounded, hover/active/focus states).
- README.md
  - Update to describe inline replace flow, artifact cleanup, adjusted usage and troubleshooting, and development notes.

### Motivation
Reduces friction by eliminating the modal and copy/paste step, speeding up prompt iteration.

### How to test
1. Reload the unpacked extension.
2. Open ChatGPT or Gemini.
3. Type a prompt and click Optimize.
   - Expect: Input replaced with improved prompt; button shows “Optimizing…” during call.
   - If API key is missing: Options page should open.
4. Verify no leftover artifacts (e.g., `<｜begin▁of▁sentence｜>`).
5. Confirm Optimize still works on contenteditable fields and textareas across SPA navigation.

### Compatibility/Edge cases
- Handles both `textarea` and `div[contenteditable=true]`.
- Dispatches `input`/`change` so site UIs react.
- Site CSP/Intercom/React console messages are unrelated and expected; they don’t affect functionality.

### Security/Privacy
- No new permissions.
- All API calls remain in the background service worker; keys stay in `chrome.storage.sync`.

### Perf
- No meaningful impact. Eliminating the modal reduces UI overhead.

### Follow-ups (separate PR)
- Options page: provider-specific model selection UI (previously in the modal).
- Optional “Clean up artifacts” toggle in Options.

### Checklist
- [x] Inline replace behavior
- [x] Button restyle
- [x] Output sanitization
- [x] README updated
- [x] No linter errors

Please review:
- UI/UX of the inline button.
- Selector robustness on ChatGPT/Gemini.
- Token sanitization patterns (add/remove any you foresee).